### PR TITLE
Add predict from kernel back

### DIFF
--- a/src/kreg/kernel/component.py
+++ b/src/kreg/kernel/component.py
@@ -55,6 +55,12 @@ class KernelComponent:
     def size(self) -> int:
         return len(self.span)
 
+    @property
+    def dim_names(self) -> str | list[str]:
+        if isinstance(self.dimensions, list):
+            return [dim.name for dim in self.dimensions]
+        return self.dimensions.name
+
     def set_span(self, data: DataFrame) -> None:
         """This function will only get triggered if the span has not been set."""
         if not hasattr(self, "_span"):

--- a/src/kreg/kernel/component.py
+++ b/src/kreg/kernel/component.py
@@ -56,6 +56,7 @@ class KernelComponent:
         return len(self.span)
 
     def set_span(self, data: DataFrame) -> None:
+        """This function will only get triggered if the span has not been set."""
         if not hasattr(self, "_span"):
             if isinstance(self.dimensions, list):
                 for dimension in self.dimensions:

--- a/src/kreg/model.py
+++ b/src/kreg/model.py
@@ -1,3 +1,5 @@
+import functools
+
 import jax
 import jax.numpy as jnp
 from msca.optim.prox import proj_capped_simplex
@@ -204,8 +206,32 @@ class KernelRegModel:
 
         return y, trim_weights
 
-    def predict(self, data, x: NDArray | None = None) -> NDArray:
+    def predict(
+        self, data, x: NDArray | None = None, from_kernel: bool = False
+    ) -> NDArray:
+        x = self.x if x is None else x
         self.attach(data, train=False)
-        pred = self.likelihood.get_param(self.x if x is None else x)
+        if from_kernel:
+            kernel_components = self.kernel.kernel_components
+            rows = [
+                jnp.asarray(data[kc.dim_names].to_numpy())
+                for kc in kernel_components
+            ]
+            inv_k_x = self.kernel.op_p @ x
+
+            def predict_row(*row):
+                k_new_x = functools.reduce(
+                    jnp.kron,
+                    [
+                        kc.kfunc(coords, kc.span)
+                        for kc, coords in zip(kernel_components, row)
+                    ],
+                )
+                return jnp.dot(k_new_x, inv_k_x)
+
+            predict_rows = jax.vmap(jax.jit(predict_row))
+            pred = predict_rows(rows)
+        else:
+            pred = self.likelihood.get_param(x)
         self.detach()
         return pred

--- a/src/kreg/model.py
+++ b/src/kreg/model.py
@@ -2,6 +2,7 @@ import functools
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 from msca.optim.prox import proj_capped_simplex
 
 from kreg.kernel.kron_kernel import KroneckerKernel
@@ -237,4 +238,4 @@ class KernelRegModel:
             self.attach(data, train=False)
             pred = self.likelihood.get_param(x)
         self.detach()
-        return pred
+        return np.asarray(pred)

--- a/src/kreg/model.py
+++ b/src/kreg/model.py
@@ -204,10 +204,8 @@ class KernelRegModel:
 
         return y, trim_weights
 
-    def predict(self, data, y: NDArray | None = None) -> NDArray:
-        self.kernel.attach(data)
-        self.likelihood.attach(data, self.kernel, train=False)
-        pred = self.likelihood.get_param(self.x if y is None else y)
-        self.kernel.clear_matrices()
-        self.likelihood.detach()
+    def predict(self, data, x: NDArray | None = None) -> NDArray:
+        self.attach(data, train=False)
+        pred = self.likelihood.get_param(self.x if x is None else x)
+        self.detach()
         return pred

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -66,3 +66,13 @@ def test_model_fit_trimming(
     )
     assert np.allclose(x, 0.0)
     assert np.allclose(trim_weights, [1.0, 1.0, 1.0, 0.0])
+
+
+def test_model_predict_from_kernel(
+    model: KernelRegModel, data: pd.DataFrame
+) -> None:
+    model.fit(data, use_direct=True)
+
+    data_pred = pd.DataFrame(dict(age_mid=np.linspace(0.0, 3.0, 7), offset=1.0))
+    y = model.predict(data_pred, from_kernel=True)
+    assert np.allclose(y, 1.0)


### PR DESCRIPTION
## Description

Modify the predict function to add predict from kernel back.

## Discussion

- Maybe we should make `_build_matrices` in the kernel class public, so that it is more natural to call from the model class
- We can also add more options to attach function in the `Model` class to account for different configurations of the attach in the predict function
