### PR TITLE
Feature/dim coords

### DIFF
--- a/src/kreg/kernel/component.py
+++ b/src/kreg/kernel/component.py
@@ -1,17 +1,15 @@
 import itertools
 
 import jax.numpy as jnp
-import numpy as np
 
 from kreg.kernel.dimension import Dimension
 from kreg.typing import (
     DataFrame,
     JAXArray,
     KernelFunction,
-    NDArray,
 )
 
-DimensionConfig = str | tuple[str, tuple[str, str] | None]
+DimensionConfig = str | dict
 
 
 class KernelComponent:
@@ -29,26 +27,31 @@ class KernelComponent:
 
     def __init__(
         self,
-        dim_config: DimensionConfig | list[DimensionConfig],
+        dim_configs: list[DimensionConfig],
         kfunc: KernelFunction,
     ) -> None:
-        self.dimensions: Dimension | list[Dimension]
-        if isinstance(dim_config, list):
-            self.dimensions = [
-                Dimension.from_config(config) for config in dim_config
-            ]
-        else:
-            self.dimensions = Dimension.from_config(dim_config)
+        self.dimensions: list[Dimension]
+        dimensions = []
+        for dim_config in dim_configs:
+            if isinstance(dim_config, str):
+                dimensions.append(Dimension(dim_config))
+            else:
+                dimensions.append(Dimension(**dim_config))
+        self.dimensions = dimensions
         self.kfunc = kfunc
 
     @property
-    def span(self) -> NDArray:
-        if isinstance(self.dimensions, list):
-            span = np.asarray(
-                list(itertools.product(*[dim.span for dim in self.dimensions])),
+    def span(self) -> JAXArray:
+        span: JAXArray = jnp.asarray(
+            list(
+                map(
+                    jnp.hstack,
+                    itertools.product(*[dim.span for dim in self.dimensions]),
+                )
             )
-        else:
-            span = self.dimensions.span
+        )
+        if len(self.dimensions) == 1 and span.shape[1] == 1:
+            span = span.ravel()
         return span
 
     @property
@@ -63,17 +66,13 @@ class KernelComponent:
 
     def set_span(self, data: DataFrame) -> None:
         """This function will only get triggered if the span has not been set."""
-        if not hasattr(self, "_span"):
-            if isinstance(self.dimensions, list):
-                for dimension in self.dimensions:
-                    dimension.set_span(data)
-
-            else:
-                self.dimensions.set_span(data)
+        for dimension in self.dimensions:
+            dimension.set_span(data)
 
     def build_kmat(self, nugget: float = 0.0) -> JAXArray:
-        span = jnp.asarray(self.span)
-        return self.kfunc(span, span) + nugget * jnp.identity(len(self))
+        return self.kfunc(self.span, self.span) + nugget * jnp.identity(
+            len(self)
+        )
 
     def __len__(self) -> int:
         return len(self.span)

--- a/src/kreg/kernel/dimension.py
+++ b/src/kreg/kernel/dimension.py
@@ -1,4 +1,4 @@
-from typing import Literal, Self
+from typing import Literal
 
 import numpy as np
 from msca.integrate.integration_weights import build_integration_weights
@@ -10,8 +10,8 @@ class Dimension:
     def __init__(
         self,
         name: str,
-        interval: tuple[str, str] | None = None,
         coords: tuple[str, ...] | None = None,
+        interval: tuple[str, str] | None = None,
     ) -> None:
         if interval is not None and coords is not None:
             raise ValueError("cannot use 'interval' and 'coords' together")
@@ -60,7 +60,7 @@ class Dimension:
                 raise ValueError("Range intervals contain gap(s)")
             self._grid = grid
             if rule == "midpoint":
-                self._span = np.asarray(data.mean(axis=1))
+                self._span = data.mean(axis=1)
             else:
                 raise ValueError(f"Unknown rule='{rule}'")
 
@@ -96,11 +96,3 @@ class Dimension:
 
     def __len__(self) -> int:
         return len(self.span)
-
-    @classmethod
-    def from_config(
-        cls, config: str | tuple[str, tuple[str, str] | None]
-    ) -> Self:
-        if isinstance(config, str):
-            return cls(config)
-        return cls(*config)

--- a/src/kreg/kernel/dimension.py
+++ b/src/kreg/kernel/dimension.py
@@ -70,10 +70,10 @@ class Dimension:
         if self.interval is None:
             row_index = np.arange(len(data), dtype=int)
             col_index = (
-                data[[self.name]]
+                data[self.columns]
                 .merge(
-                    DataFrame({self.name: self.span}).reset_index(),
-                    on=self.name,
+                    DataFrame(self.span, columns=self.columns).reset_index(),
+                    on=self.columns,
                     how="left",
                 )["index"]
                 .to_numpy()

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -1,0 +1,36 @@
+import jax.numpy as jnp
+import pandas as pd
+
+from kreg.kernel.component import KernelComponent
+from kreg.kernel.factory import build_exp_similarity_kfunc, vectorize_kfunc
+
+
+def test_hierarchical_kernel() -> None:
+    kfunc = vectorize_kfunc(
+        build_exp_similarity_kfunc(jnp.asarray([10.0, 10.0, 10.0]))
+    )
+    kernel_component = KernelComponent(
+        # we decided to always provide a list of dim_configs here, it can be
+        # a str for name or a dict for more options
+        [
+            {
+                "name": "age_mid",
+                "coords": ("super_region_id", "region_id", "location_id"),
+            }
+        ],
+        kfunc,
+    )
+
+    data = pd.DataFrame(
+        {
+            "super_region_id": [0, 0, 0, 1, 1, 1],
+            "region_id": [0, 0, 1, 2, 2, 3],
+            "location_id": [0, 1, 2, 3, 4, 5],
+        }
+    )
+
+    kernel_component.set_span(data)
+    # six unique rows and three location id columns
+    assert kernel_component.span.shape == (6, 3)
+    kmat = kernel_component.build_kmat()
+    assert kmat.shape == (6, 6)


### PR DESCRIPTION
## Descriptions
Add capability for hierarchical kernel
* Add `coords` argument for `Dimension` allows user to specify coordinates for the dimension. If not provided, it will use dimension's name to search and build the grid and span
* If both `coords` and `interval` is provided it will error out, we do not support integration for multi-coordinates dimension for now.

## Note
* Interface for constructing `KernelComponent` changes a bit for extensibility and simplicity. We always require a list of dimension config, and dimension config can be a str or a dictionary with detailed specifications.
* For example, please check `tests/test_kernel.py`