### PR TITLE
Switched to only warn on failed linesearch

### DIFF
--- a/src/kreg/kernel/component.py
+++ b/src/kreg/kernel/component.py
@@ -3,11 +3,7 @@ import itertools
 import jax.numpy as jnp
 
 from kreg.kernel.dimension import Dimension
-from kreg.typing import (
-    DataFrame,
-    JAXArray,
-    KernelFunction,
-)
+from kreg.typing import DataFrame, JAXArray, KernelFunction
 
 DimensionConfig = str | dict
 
@@ -59,10 +55,15 @@ class KernelComponent:
         return len(self.span)
 
     @property
-    def dim_names(self) -> str | list[str]:
-        if isinstance(self.dimensions, list):
-            return [dim.name for dim in self.dimensions]
-        return self.dimensions.name
+    def dim_names(self) -> list[str]:
+        return [dim.name for dim in self.dimensions]
+
+    @property
+    def columns(self) -> list[str]:
+        columns = []
+        for dim in self.dimensions:
+            columns.extend(dim.columns)
+        return columns
 
     def set_span(self, data: DataFrame) -> None:
         """This function will only get triggered if the span has not been set."""

--- a/src/kreg/model.py
+++ b/src/kreg/model.py
@@ -215,7 +215,7 @@ class KernelRegModel:
             self.kernel.attach(data)
             kernel_components = self.kernel.kernel_components
             rows = [
-                jnp.asarray(data[kc.dim_names].to_numpy())
+                jnp.asarray(data[kc.columns].to_numpy())
                 for kc in kernel_components
             ]
             inv_k_x = self.kernel.op_p @ x

--- a/src/kreg/solver/line_search.py
+++ b/src/kreg/solver/line_search.py
@@ -31,7 +31,7 @@ def armijo_line_search(
             )
         step *= shrinkage
         new_x = x - step * p
-        new_val = objective(new_x)
+        new_val, new_grad = objective(new_x), gradient(new_x)
     armijo_ratio = (val - new_val) / (step * jnp.dot(g, p))
 
     return step, armijo_ratio, (jnp.linalg.norm(new_grad) / jnp.linalg.norm(g))


### PR DESCRIPTION
Previously, we're having errors on failed linesearch, I suspect this may be a numerical issue, and we reach the maximum achievable tolerance, and no longer find sufficiently good descent directions, but am not sure. This will give us a sense of what's happening.