### PR TITLE
Normalize kernel matrix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kreg"
-version = "0.3.0"
+version = "0.4.0"
 description = "Python package template"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/kreg/kernel/component.py
+++ b/src/kreg/kernel/component.py
@@ -71,7 +71,7 @@ class KernelComponent:
             dimension.set_span(data)
 
     def build_kmat(
-        self, nugget: float = 0.0, normalize: bool = True
+        self, nugget: float = 0.0, normalize: bool = False
     ) -> JAXArray:
         mat = self.kfunc(self.span, self.span)
         if normalize:

--- a/src/kreg/kernel/component.py
+++ b/src/kreg/kernel/component.py
@@ -70,10 +70,14 @@ class KernelComponent:
         for dimension in self.dimensions:
             dimension.set_span(data)
 
-    def build_kmat(self, nugget: float = 0.0) -> JAXArray:
-        return self.kfunc(self.span, self.span) + nugget * jnp.identity(
-            len(self)
-        )
+    def build_kmat(
+        self, nugget: float = 0.0, normalize: bool = True
+    ) -> JAXArray:
+        mat = self.kfunc(self.span, self.span)
+        if normalize:
+            vec = jnp.sqrt(mat.max(axis=0))
+            mat = mat / jnp.outer(vec, vec)
+        return mat + nugget * jnp.identity(len(self))
 
     def __len__(self) -> int:
         return len(self.span)

--- a/src/kreg/kernel/kron_kernel.py
+++ b/src/kreg/kernel/kron_kernel.py
@@ -21,6 +21,9 @@ class KroneckerKernel:
         List of value grids, unique values for each dimension.
     nugget
         Regularization for the kernel matrix.
+    normalize
+        If True, will normalize the kernel matrix so that the diagonal elements
+        are all ones. Default is False.
 
     """
 
@@ -28,7 +31,7 @@ class KroneckerKernel:
         self,
         kernel_components: list[KernelComponent],
         nugget: float = 5e-8,
-        normalize: bool = True,
+        normalize: bool = False,
     ) -> None:
         self.kernel_components = kernel_components
         self.nugget = nugget

--- a/src/kreg/kernel/kron_kernel.py
+++ b/src/kreg/kernel/kron_kernel.py
@@ -28,6 +28,7 @@ class KroneckerKernel:
         self,
         kernel_components: list[KernelComponent],
         nugget: float = 5e-8,
+        normalize: bool = True,
     ) -> None:
         self.kernel_components = kernel_components
         self.nugget = nugget
@@ -46,6 +47,7 @@ class KroneckerKernel:
                 self.columns.append(columns)
             else:
                 self.columns.extend(columns)
+        self.normalize = normalize
 
         self.kmats: list[JAXArray]
         self.op_k: KroneckerProduct
@@ -81,7 +83,7 @@ class KroneckerKernel:
 
     def _build_matrices(self):
         self.kmats = [
-            component.build_kmat(self.nugget)
+            component.build_kmat(self.nugget, self.normalize)
             for component in self.kernel_components
         ]
         self.op_k = KroneckerProduct(self.kmats)

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -2,7 +2,11 @@ import jax.numpy as jnp
 import pandas as pd
 
 from kreg.kernel.component import KernelComponent
-from kreg.kernel.factory import build_exp_similarity_kfunc, vectorize_kfunc
+from kreg.kernel.factory import (
+    build_exp_similarity_kfunc,
+    build_matern_three_half_kfunc,
+    vectorize_kfunc,
+)
 
 
 def test_hierarchical_kernel() -> None:
@@ -34,3 +38,23 @@ def test_hierarchical_kernel() -> None:
     assert kernel_component.span.shape == (6, 3)
     kmat = kernel_component.build_kmat()
     assert kmat.shape == (6, 6)
+
+
+def test_kernel_component_normalization() -> None:
+    kfunc_1 = build_matern_three_half_kfunc(rho=5.0)
+    kfunc_2 = build_matern_three_half_kfunc(rho=10.0)
+
+    def kfunc(x, y):
+        return kfunc_1(x, y) + kfunc_2(x, y)
+
+    kernel_component = KernelComponent(["x"], vectorize_kfunc(kfunc))
+
+    data = pd.DataFrame({"x": jnp.linspace(0, 10, 11)})
+
+    kernel_component.set_span(data)
+
+    kmat = kernel_component.build_kmat(nugget=0.0, normalize=True)
+    assert jnp.allclose(jnp.diag(kmat), 1.0)
+
+    kmat = kernel_component.build_kmat(nugget=0.0, normalize=False)
+    assert jnp.allclose(jnp.diag(kmat), 2.0)


### PR DESCRIPTION
## Description
Add `normalize` option to `KernelComponent.build_kmat` and `KroneckerKernel`. Normalization is necessary to make sure the constant tail kernel scale properly compare to the rest of the kernel.